### PR TITLE
(cosmetic) allow Python to clean up plot when the 'X' button is clicked

### DIFF
--- a/superconductor-spectral.py
+++ b/superconductor-spectral.py
@@ -12,6 +12,9 @@ with the Spectral method
 d psi / d t = (1+i*alpha) * nabla^2 psi + psi - (1-i*beta)*|psi|^2*psi
 """
 
+def exit_all(event):
+	""" exits the program """
+	raise SystemExit
 
 def main():
 	""" Superconductor simulation """
@@ -49,6 +52,7 @@ def main():
 	
 	# prep figure
 	fig = plt.figure(figsize=(4,4), dpi=150)
+	fig.canvas.mpl_connect('close_event', exit_all)
 	outputCount = 1
 	
 	# Simulation Main Loop


### PR DESCRIPTION
Currently, when your plot window is closed, it pops right back up, and continues from the beginning of the simulation. This causes the console output timestamp to fall out-of-sync with your display results.

Hope this helps a fellow /r/physicsgiffer! :grin: 